### PR TITLE
adding default value to the second, optional linkify parameter

### DIFF
--- a/socialator.php
+++ b/socialator.php
@@ -81,7 +81,7 @@
 	}
 
     /* Change Links in Post to <a> Tags */
-	function linkify($text, $platform) {
+	function linkify($text, $platform = "") {
         // Change Hashtags to links
 		$hastagPrefix = '';
 		if($platform == 'facebook'){


### PR DESCRIPTION
This is to stop PHP from printing warnings 'PHP warning: Missing argument 2 for linkify()'
